### PR TITLE
Add folia-supported flag to plugin.yml

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,6 +5,7 @@ api-version: '1.21'
 authors: [ Kartoffelchipss ]
 description: A simple plugin to add Links to your server
 website: strassburger.org
+folia-supported: true
 
 commands:
   serverlinksz:


### PR DESCRIPTION
It looks like ServerLinks works with Folia out of the box. I just tried it and it works.
I think it's safe to mark it as supported for Folia servers.